### PR TITLE
fix: add default option to fallback to holo monomers in PPIDataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ I/O operations. fastpdb is a dependency of pinder-core, and pip will attempt to
 install it for you during the installation of pinder. Pre-built wheels of
 fastpdb are available on PyPI for the following platforms:
 1. Linux with `glibc>=2.34` (e.g., Debian 12, Ubuntu 22.04, RHEL 9, etc.)
-2. Intel-based (x86, not Apple Silicon) MacOS Sierra (10.12) or newer
+2. MacOS Sierra (10.12) or newer
 3. Windows
 
 If your platform doesn't match these conditions, you will not get a wheel and
@@ -50,24 +50,12 @@ environment. This can be done using
 [`mamba`](https://github.com/mamba-org/mamba) or `conda` (you can swap `mamba`
 for `conda` for the same functionality):
 
-**Linux and Intel-based (x86-64) CPU architecture**
 
 ```bash
 mamba create --name pinder python=3.10
 mamba activate pinder
 ```
 
-**Apple Silicon-based (ARM) CPU architecture**
-
-Unfortunately, until all pinder dependencies have an ARM wheel on PyPi, we have to instruct conda to use an osx-64 target arch.
-
-```bash
-CONDA_SUBDIR=osx-64 mamba create --name pinder python=3.10
-mamba activate pinder
-mamba env config vars set CONDA_SUBDIR=osx-64
-mamba deactivate
-mamba activate pinder
-```
 
 or via `venv` from the Python standard library:
 
@@ -388,31 +376,7 @@ Each model decoy should have exactly two chains: {R, L} for {Receptor, Ligand}, 
 ```
 
 For more details on the implementations of the eval metrics, see the [eval docs](examples/eval/).
-
-
-### 📨 pinder_create_submission
-
-It is recommended to run through the `pinder_eval` script at least once to get familiar with the format and any common issues encountered with input validation. Once you are ready to submit your method to the leaderboard, use the `pinder_create_submission` CLI script to create a single archive to upload:
-
-```
-pinder_create_submission --help
-
-usage: pinder_create_submission [-h] --eval_dir eval_dir [--submission_name submission_name]
-
-optional arguments:
-  -h, --help            show this help message and exit
-  --eval_dir eval_dir, -f eval_dir
-                        Path to eval
-  --submission_name submission_name, -s submission_name, -n submission_name
-                        Optional name for submission
-
-```
-
-This will create a single archive which would be uploaded to a google drive that will be configured shortly.
-
-Leaderboards will be generated based on the valid submissions received.
-
-For more details on leaderboard generation, see the [Quarto dashboard](examples/eval/leaderboard/pinder-eval.qmd) and the [MethodMetrics](src/pinder-eval/pinder/eval/dockq/method.py) implementation.
+For more details on leaderboard generation, see the [MethodMetrics](src/pinder-eval/pinder/eval/dockq/method.py) implementation.
 
 
 ## 4. 🧪 Training set

--- a/src/pinder-core/pinder/core/loader/dataset.py
+++ b/src/pinder-core/pinder/core/loader/dataset.py
@@ -40,6 +40,7 @@ class PPIDataset(Dataset):  # type: ignore
         k: int = 10,
         parallel: bool = False,
         max_workers: int | None = None,
+        fallback_to_holo: bool = True,
     ) -> None:
         self.node_types = node_types
         self.split = split
@@ -57,6 +58,7 @@ class PPIDataset(Dataset):  # type: ignore
         self.k = k
         self.parallel = parallel
         self.max_workers = max_workers
+        self.fallback_to_holo = fallback_to_holo
         default_file_dir = Path(root) / "filenames"
         self.filenames_dir = default_file_dir
         if filenames_dir:
@@ -105,6 +107,7 @@ class PPIDataset(Dataset):  # type: ignore
         output_file: Path,
         add_edges: bool = True,
         k: int = 10,
+        fallback_to_holo: bool = True,
     ) -> bool:
         try:
             data = PairedPDB.from_pinder_system(
@@ -114,6 +117,7 @@ class PPIDataset(Dataset):  # type: ignore
                 node_types=node_types,
                 add_edges=add_edges,
                 k=k,
+                fallback_to_holo=fallback_to_holo,
             )
             torch.save(data, output_file)
             return True
@@ -134,6 +138,7 @@ class PPIDataset(Dataset):  # type: ignore
             bool,
             int,
             bool,
+            bool,
         ],
     ) -> str | None:
         (
@@ -147,6 +152,7 @@ class PPIDataset(Dataset):  # type: ignore
             add_edges,
             k,
             force_reload,
+            fallback_to_holo,
         ) = args
         if not hasattr(system, "entry"):
             return None
@@ -170,6 +176,7 @@ class PPIDataset(Dataset):  # type: ignore
             to_write,
             add_edges,
             k,
+            fallback_to_holo,
         )
         if processed:
             return pinder_id
@@ -189,6 +196,7 @@ class PPIDataset(Dataset):  # type: ignore
                     self.add_edges,
                     self.k,
                     self.force_reload,
+                    self.fallback_to_holo,
                 )
                 for dimer in self.loader.dimers
             )
@@ -238,6 +246,7 @@ class PPIDataset(Dataset):  # type: ignore
                     to_write,
                     self.add_edges,
                     self.k,
+                    self.fallback_to_holo,
                 )
                 if processed:
                     self.filenames.add(pinder_id)

--- a/src/pinder-core/pinder/core/loader/geodata.py
+++ b/src/pinder-core/pinder/core/loader/geodata.py
@@ -79,10 +79,17 @@ class PairedPDB(HeteroData):  # type: ignore
         monomer2: str = "holo_ligand",
         add_edges: bool = True,
         k: int = 10,
+        fallback_to_holo: bool = True,
     ) -> PairedPDB:
         chain1_struc = getattr(system, monomer1)
+        if chain1_struc is None and fallback_to_holo:
+            log.debug(f"No {monomer1} found, falling back to holo_receptor")
+            chain1_struc = getattr(system, "holo_receptor")
         chain1_struc.filter("element", mask=["H"], negate=True, copy=False)
         chain2_struc = getattr(system, monomer2)
+        if chain2_struc is None and fallback_to_holo:
+            log.debug(f"No {monomer2} found, falling back to holo_ligand")
+            chain2_struc = getattr(system, "holo_ligand")
         chain2_struc.filter("element", mask=["H"], negate=True, copy=False)
         return cls.from_structure_pair(
             node_types=node_types,

--- a/src/pinder-core/pinder/core/loader/structure.py
+++ b/src/pinder-core/pinder/core/loader/structure.py
@@ -45,6 +45,7 @@ class Structure:
     uniprot_map: Union[Optional[Path], Optional[pd.DataFrame]] = None
     pinder_id: Optional[str] = None
     atom_array: AtomArray = None
+    pdb_engine: str = "fastpdb"
 
     @staticmethod
     def read_pdb(path: Path, pdb_engine: str = "fastpdb") -> AtomArray:
@@ -107,7 +108,10 @@ class Structure:
             uniprot_map = None
 
         return Structure(
-            filepath=combined_pdb, uniprot_map=uniprot_map, atom_array=combined_arr
+            filepath=combined_pdb,
+            uniprot_map=uniprot_map,
+            atom_array=combined_arr,
+            pdb_engine=self.pdb_engine,
         )
 
     def filter(
@@ -127,6 +131,7 @@ class Structure:
                 uniprot_map=self.uniprot_mapping,
                 pinder_id=self.pinder_id,
                 atom_array=arr,
+                pdb_engine=self.pdb_engine,
             )
         self.atom_array = self.atom_array[atom_mask]
         return None
@@ -184,12 +189,14 @@ class Structure:
                 uniprot_map=self.uniprot_map,
                 pinder_id=self.pinder_id,
                 atom_array=target_at,
+                pdb_engine=self.pdb_engine,
             )
             other_struct = Structure(
                 filepath=other.filepath,
                 uniprot_map=other.uniprot_map,
                 pinder_id=other.pinder_id,
                 atom_array=ref_at,
+                pdb_engine=self.pdb_engine,
             )
             return self_struct, other_struct
         other.atom_array = ref_at
@@ -307,6 +314,7 @@ class Structure:
                 uniprot_map=self.uniprot_map,
                 pinder_id=self.pinder_id,
                 atom_array=superimposed,
+                pdb_engine=self.pdb_engine,
             ),
             raw_rmsd,
             refined_rmsd,
@@ -493,7 +501,7 @@ class Structure:
     def __post_init__(self) -> None:
         # pydantic v2 renames this to dataclass post_init
         if self.atom_array is None:
-            self.atom_array = self.read_pdb(self.filepath)
+            self.atom_array = self.read_pdb(self.filepath, pdb_engine=self.pdb_engine)
         if not self.pinder_id:
             self.pinder_id = self.filepath.stem
 

--- a/src/pinder-data/pinder/data/pipeline/tasks.py
+++ b/src/pinder-data/pinder/data/pipeline/tasks.py
@@ -51,30 +51,6 @@ def foldseek_pdb_glob(data_dir: Path) -> list[Path]:
     return list(data_dir.glob("*.pdb"))
 
 
-def plm_embedding_glob(data_dir: Path) -> list[Path]:
-    return list(data_dir.glob("embeddings_*.npz"))
-
-
-def plm_embedding_pairs(data_dir: Path) -> list[tuple[Path, Path]]:
-    npz_files = plm_embedding_glob(data_dir)
-    npz_pairs = []
-    for i in range(len(npz_files)):
-        for j in range(i + 1, len(npz_files)):
-            chunk1 = npz_files[i]
-            chunk2 = npz_files[j]
-            output_dir = chunk1.parent / "similarities"
-            output_file = output_dir / f"similarities_{chunk1.stem}_{chunk2.stem}.txt"
-            if output_file.is_file():
-                continue
-            npz_pairs.append((chunk1, chunk2))
-    return npz_pairs
-
-
-def plm_embedding_fasta(data_dir: Path) -> list[Path]:
-    fasta_file = list(data_dir.glob("*.fasta"))
-    return fasta_file
-
-
 def graph_type_glob(data_dir: Path) -> list[tuple[str, bool]]:
     graph_specs = []
     for g in data_dir.glob("cleaned_*_alignment_graph.pkl"):
@@ -115,9 +91,6 @@ DATA_GLOBS: dict[str, Callable[[Path], INPUT_TYPES]] = {
     "two_char_codes": two_char_code_rsync,
     "pdb_ids": pdb_id_glob,
     "foldseek": foldseek_pdb_glob,
-    "plm_fasta": plm_embedding_fasta,
-    "plm_embeddings": plm_embedding_glob,
-    "plm_embedding_pairs": plm_embedding_pairs,
     "graph_types": graph_type_glob,
     "putative_apo_pairings": putative_apo_pairings,
 }

--- a/tests/data/test_graphql.py
+++ b/tests/data/test_graphql.py
@@ -58,7 +58,7 @@ def test_fetch_entry_annotations(pdb_id, tmp_path):
     assert {"DCAF15_WD40", "RRM_1", "CPSF_A", "DDA1"}.issubset(
         set(pfam_df.rcsb_pfam_identifier)
     )
-    assert set(feature_df.type) == EXPECTED_FEATURE_TYPES
+    assert set(feature_df.type).issuperset(EXPECTED_FEATURE_TYPES)
     assert set(feature_df.asym_id) == {"C", "A", "E", "B", "D"}
     assert set(annotation_df.annotation_id) == EXPECTED_ANNOTATION_IDS
 

--- a/tests/data/test_tasks.py
+++ b/tests/data/test_tasks.py
@@ -19,18 +19,6 @@ def test_foldseek_pdb_glob(pinder_data_cp):
     assert len(tasks.foldseek_pdb_glob(pdb_dir)) == 30
 
 
-def test_plm_embedding_pairs(tmp_path, pinder_data_cp):
-    from pinder.data.pipeline import tasks
-
-    assert len(tasks.plm_embedding_pairs(pinder_data_cp)) == 0
-    embed_files = tasks.plm_embedding_glob(pinder_data_cp)
-    assert len(embed_files) == 1
-    npz = embed_files[0]
-    shutil.copy(npz, tmp_path / npz.name)
-    shutil.copy(npz, tmp_path / "embeddings_1.npz")
-    assert len(tasks.plm_embedding_pairs(tmp_path)) == 1
-
-
 @pytest.mark.parametrize(
     "step_name, input_type, data_subdir, cache_func, cache_kwargs, scatter_func, batch_size, expected_batches",
     [


### PR DESCRIPTION
Introduces an option (default True) to `PPIDataset` torch geometric dataset to fallback to holo monomers if the user-specified monomer1/2 are not available for the `PinderSystem` being loaded. 

Closes #10 

