### PR TITLE
Fix unbound RMSD calculation in low homology structures

### DIFF
--- a/src/pinder-core/pinder/core/index/system.py
+++ b/src/pinder-core/pinder/core/index/system.py
@@ -69,6 +69,7 @@ def unbound_rmsd_with_mask_fallback(
         raw_rmsd (float): The RMSD between the mobile and fixed structure after superposition (without outlier rejection).
 
     """
+    raw_rmsd: float
     try:
         _, raw_rmsd, _ = mobile.superimpose(fixed)
     except ValueError as e:

--- a/src/pinder-core/pinder/core/loader/loader.py
+++ b/src/pinder-core/pinder/core/loader/loader.py
@@ -364,6 +364,8 @@ class PinderLoader:
                 system, self.base_filters, self.sub_filters
             )
             if not isinstance(system, PinderSystem):
+                # Select a new random system, previous one failed filters
+                idx = random.choice(list(range(len(self))))
                 continue
 
             if self.pre_specified_monomers is not None:

--- a/src/pinder-core/pinder/core/loader/structure.py
+++ b/src/pinder-core/pinder/core/loader/structure.py
@@ -657,9 +657,12 @@ def _superimpose_common_atoms(
         # Only run fallback if number of anchors is the issue
         if "anchor" not in str(error):
             raise
-        fixed_common_mask = struc.filter_intersection(fixed, mobile)
+        fixed_masked, mobile_masked = surgery.fix_annotation_mismatch(
+            fixed, mobile, ["element", "ins_code", "b_factor"]
+        )
+        fixed_common_mask = struc.filter_intersection(fixed_masked, mobile_masked)
         fixed_coord = fixed.coord[fixed_common_mask]
-        mobile_common_mask = struc.filter_intersection(mobile, fixed)
+        mobile_common_mask = struc.filter_intersection(mobile_masked, fixed_masked)
         mobile_coord = mobile.coord[mobile_common_mask]
         _, transformation = struc.superimpose(fixed_coord, mobile_coord)
         mobile_superimposed = transformation.apply(mobile)

--- a/src/pinder-core/pinder/core/structure/superimpose.py
+++ b/src/pinder-core/pinder/core/structure/superimpose.py
@@ -100,7 +100,9 @@ def superimpose_chain(
     if len(anchor_indices) < min_anchors:
         # Fallback: Match all CA atoms
         if len(fixed_ca_indices) != len(mobile_ca_indices):
-            raise ValueError("Tried fallback, but number of CA atoms does not match")
+            raise ValueError(
+                "Tried fallback, but number of CA atoms does not match and insufficient anchors were found"
+            )
         fixed_anchor_indices = fixed_ca_indices
         mobile_anchor_indices = mobile_ca_indices
     else:

--- a/src/pinder-core/pinder/core/structure/surgery.py
+++ b/src/pinder-core/pinder/core/structure/surgery.py
@@ -32,7 +32,7 @@ def remove_annotations(
 def fix_annotation_mismatch(
     ref: AtomArray,
     decoys: AtomArrayStack,
-    categories: list[str] = ["element", "ins_code"],
+    categories: list[str] = ["element", "ins_code", "b_factor"],
 ) -> tuple[AtomArray, AtomArrayStack]:
     for annot in ref.get_annotation_categories():
         ref_annot = ref.get_annotation(annot)

--- a/tests/core/structure/test_superimpose.py
+++ b/tests/core/structure/test_superimpose.py
@@ -2,6 +2,7 @@ import pytest
 from pinder.core.loader.structure import Structure
 from pinder.core import PinderSystem
 from pinder.core.index.system import unbound_rmsd_with_mask_fallback
+from pinder.core.structure.superimpose import superimpose_chain
 
 
 @pytest.mark.parametrize(
@@ -110,14 +111,18 @@ def test_create_masked_bound_unbound_complexes(
 @pytest.mark.parametrize(
     ["pinder_id", "expected_rmsd"],
     [
+        # case where insufficient calpha anchors are found prior to cropping/masking
+        # furthermore, the apo monomer is missing b-factor annotations whereas holo is not
+        # so struc.filter_intersection needs to be applied on the "fixed" structure
         (
             "4ag4__A1_Q08345--4ag4__C1_UNDEFINED",
-            pytest.approx(16.158762),
-        ),  # case where insufficient C-alpha anchors are found prior to cropping/masking
+            pytest.approx(22.101498),
+        ),
+        # peptide cluster receptor case with paired apo
         (
             "5mb9__A1_G0RZX9--5mb9__D1_G0RYD6",
             pytest.approx(0.67709655),
-        ),  # peptide cluster receptor case with paired apo
+        ),
     ],
 )
 def test_unbound_rmsd_with_mask_fallback(
@@ -129,3 +134,20 @@ def test_unbound_rmsd_with_mask_fallback(
     apo_R = ps.apo_receptor or ps.holo_receptor
     rmsd = unbound_rmsd_with_mask_fallback(apo_R, holo_R)
     assert rmsd == expected_rmsd
+
+
+def test_superimpose_chain_fallback_exception():
+    """
+    Test that ensures that the string `anchor` is present in the exception message
+    when the number of anchors is insufficient in the fallback case.
+    This is necessary as the fallback behavior in Structure.superimpose() is to
+    fallback to all-atom superposition after filtering intersecting atoms
+    (as opposed to a sequence-based superposition).
+    """
+
+    ps = PinderSystem("4ag4__A1_Q08345--4ag4__C1_UNDEFINED")
+    holo_R = ps.aligned_holo_R
+    apo_R = ps.apo_receptor or ps.holo_receptor
+    with pytest.raises(ValueError) as e_info:
+        ret = superimpose_chain(holo_R.atom_array, apo_R.atom_array, max_iterations=1)
+        assert "anchor" in str(e_info.value)


### PR DESCRIPTION
## Added 
* `unbound_rmsd_with_mask_fallback` helper method used in `PinderSystem.unbound_rmsd` to first attempt default superposition and fallback to "cropped" superposition (covered in more detail [here](https://pinder-org.github.io/pinder/superposition.html)

## Fixed
* Bug reported by @ntoxeg in https://github.com/pinder-org/pinder/issues/13 where the `PinderLoader.__getitem__` method never re-samples a new system index in the case where the previous `PinderSystem` fails filters
* Bug underlying the reason for the failing system filter raised when applying the `filters.FilterSubRmsds(rmsd_cutoff=7.5)` filter which relied on the `PinderSystem.unbound_rmsd` method
  * In the specific system reported in PR #13, the problem was two-fold: 
    * `Structure.superimpose` uses a helper method that first tries to perform sequence-based superposition followed by refinement and, in the case of failure, it is supposed to fallback to coordinate-based superposition. The fallback behavior was controlled by whether the string `anchor` was part of the exception message. In this case, there _are_ sufficient CA atoms, but the number of anchors identified is 1 (fewer than `min_anchors`). In this branch, the `anchor` string was missing and so the fallback method was never called
    * When the fallback method _is_ called, we need to perform some "surgery" on the AtomArray before calling `struc.filter_intersection`. In this case, the holo receptor monomer had b-factors defined, but the apo monomer did not and so zero atoms are in common. After applying the patch to the atom arrays used to identify common atom indices, the method proceeds as expected and does not raise an exception (albeit, it returns a very high RMSD since there is low homology/domain overlap and this apo pairing was annotated as such: 
```python
>>> from pinder.core import get_index
>>> index = get_index()
>>> pid = "4ag4__A1_Q08345--4ag4__C1_UNDEFINED"
>>> index.query(f'id == "{pid}"').apo_R_quality.values[0]
'low'
```


Thanks for reporting the bug and proposing an initial patch @ntoxeg! Very much appreciated 🙏 

With the changes above, your previous loader config should work without ever needing to re-sample (but the re-sampling of the system index was indeed a bug and has also been addressed here!)


Closes #13 