### PR TITLE
fix: holo monomer fallback in loader

### DIFF
--- a/src/pinder-core/pinder/core/loader/loader.py
+++ b/src/pinder-core/pinder/core/loader/loader.py
@@ -171,6 +171,7 @@ def _create_target_feature_complex(
     # Check to ensure that the monomer wasn't filtered out by a PinderFilterSubBase
     if decoy_R is None and fallback_to_holo:
         selected_monomers["R"] = "holo"
+        decoy_R = getattr(system, selected_monomers["R"] + "_receptor")
     if decoy_L is None and fallback_to_holo:
         selected_monomers["L"] = "holo"
         decoy_L = getattr(system, selected_monomers["L"] + "_ligand")

--- a/src/pinder-core/pinder/core/utils/timer.py
+++ b/src/pinder-core/pinder/core/utils/timer.py
@@ -20,7 +20,7 @@ def timeit(func: Callable[P, T]) -> Callable[P, T]:
         result = None
         try:
             result = func(*args, **kwargs)
-            log.info(f"runtime succeeded: {time() - ts:>9.2f}s")
+            log.debug(f"runtime succeeded: {time() - ts:>9.2f}s")
         except Exception:
             log.error(f"runtime failed: {time() - ts:>9.2f}s")
             raise


### PR DESCRIPTION
Fixes typo that caused the holo fallback in `pinder.core.loader.loader.select_monomer` to never get applied in the case where the alternate receptor monomer is filtered out 