### PR TITLE
feat: upgrade biotite to version >= 1.0

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -15,7 +15,7 @@ jobs:
     name: Test
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12"]
     if: |
         github.repository == 'pinder-org/pinder' &&
         ! contains(toJSON(github.event.commits.*.message), '[skip ci]')

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -33,7 +33,7 @@ jobs:
         run: |
             # install foldseek:
             # https://github.com/steineggerlab/foldseek
-            wget https://mmseqs.com/foldseek/foldseek-linux-avx2.tar.gz
+            wget --secure-protocol=TLSv1_2 https://mmseqs.com/foldseek/foldseek-linux-avx2.tar.gz
             tar xvzf foldseek-linux-avx2.tar.gz
             # https://www.scivision.dev/github-actions-path-append/
             echo $(pwd)/foldseek/bin/ >> $GITHUB_PATH
@@ -41,7 +41,7 @@ jobs:
       - name: install mmseq
         shell: bash
         run: |
-            wget https://mmseqs.com/latest/mmseqs-linux-avx2.tar.gz
+            wget --secure-protocol=TLSv1_2 https://mmseqs.com/latest/mmseqs-linux-avx2.tar.gz
             tar xvfz mmseqs-linux-avx2.tar.gz
             echo $(pwd)/mmseqs/bin/ >> $GITHUB_PATH
 
@@ -50,7 +50,7 @@ jobs:
         run: |
             # install iAlign:
             # https://sites.gatech.edu/cssb/ialign/
-            wget http://cssb2.biology.gatech.edu/skolnick/files/iAlign/ialign_64_v1.1b2.tar.gz
+            wget --secure-protocol=TLSv1_2 http://cssb2.biology.gatech.edu/skolnick/files/iAlign/ialign_64_v1.1b2.tar.gz
             tar xvzf ialign_64_v1.1b2.tar.gz
             # https://www.scivision.dev/github-actions-path-append/
             echo $(pwd)/ialign/bin/ >> $GITHUB_PATH

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -33,7 +33,7 @@ jobs:
         run: |
             # install foldseek:
             # https://github.com/steineggerlab/foldseek
-            curl -LO https://mmseqs.com/foldseek/foldseek-linux-avx2.tar.gz
+            curl -LO https://github.com/steineggerlab/foldseek/releases/download/9-427df8a/foldseek-linux-avx2.tar.gz
             tar xvzf foldseek-linux-avx2.tar.gz
             # https://www.scivision.dev/github-actions-path-append/
             echo $(pwd)/foldseek/bin/ >> $GITHUB_PATH
@@ -41,7 +41,7 @@ jobs:
       - name: install mmseq
         shell: bash
         run: |
-            curl -LO https://mmseqs.com/latest/mmseqs-linux-avx2.tar.gz
+            curl -LO https://github.com/soedinglab/MMseqs2/releases/download/15-6f452/mmseqs-linux-avx2.tar.gz
             tar xvfz mmseqs-linux-avx2.tar.gz
             echo $(pwd)/mmseqs/bin/ >> $GITHUB_PATH
 

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -33,7 +33,7 @@ jobs:
         run: |
             # install foldseek:
             # https://github.com/steineggerlab/foldseek
-            wget --secure-protocol=TLSv1_2 https://mmseqs.com/foldseek/foldseek-linux-avx2.tar.gz
+            curl -LO https://mmseqs.com/foldseek/foldseek-linux-avx2.tar.gz
             tar xvzf foldseek-linux-avx2.tar.gz
             # https://www.scivision.dev/github-actions-path-append/
             echo $(pwd)/foldseek/bin/ >> $GITHUB_PATH
@@ -41,7 +41,7 @@ jobs:
       - name: install mmseq
         shell: bash
         run: |
-            wget --secure-protocol=TLSv1_2 https://mmseqs.com/latest/mmseqs-linux-avx2.tar.gz
+            curl -LO https://mmseqs.com/latest/mmseqs-linux-avx2.tar.gz
             tar xvfz mmseqs-linux-avx2.tar.gz
             echo $(pwd)/mmseqs/bin/ >> $GITHUB_PATH
 
@@ -50,7 +50,7 @@ jobs:
         run: |
             # install iAlign:
             # https://sites.gatech.edu/cssb/ialign/
-            wget --secure-protocol=TLSv1_2 http://cssb2.biology.gatech.edu/skolnick/files/iAlign/ialign_64_v1.1b2.tar.gz
+            curl -LO http://cssb2.biology.gatech.edu/skolnick/files/iAlign/ialign_64_v1.1b2.tar.gz
             tar xvzf ialign_64_v1.1b2.tar.gz
             # https://www.scivision.dev/github-actions-path-append/
             echo $(pwd)/ialign/bin/ >> $GITHUB_PATH

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -15,7 +15,7 @@ jobs:
     name: Test
     strategy:
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12"]
     if: |
         github.repository == 'pinder-org/pinder' &&
         ! contains(toJSON(github.event.commits.*.message), '[skip ci]')

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -15,7 +15,7 @@ jobs:
     name: Test
     strategy:
       matrix:
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.10", "3.11"]
     if: |
         github.repository == 'pinder-org/pinder' &&
         ! contains(toJSON(github.event.commits.*.message), '[skip ci]')

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -31,7 +31,7 @@ jobs:
         run: |
             # install foldseek:
             # https://github.com/steineggerlab/foldseek
-            wget https://mmseqs.com/foldseek/foldseek-linux-avx2.tar.gz
+            curl -LO https://github.com/steineggerlab/foldseek/releases/download/9-427df8a/foldseek-linux-avx2.tar.gz
             tar xvzf foldseek-linux-avx2.tar.gz
             # https://www.scivision.dev/github-actions-path-append/
             echo $(pwd)/foldseek/bin/ >> $GITHUB_PATH
@@ -39,7 +39,7 @@ jobs:
       - name: install mmseq
         shell: bash
         run: |
-            wget https://mmseqs.com/latest/mmseqs-linux-avx2.tar.gz
+            curl -LO https://github.com/soedinglab/MMseqs2/releases/download/15-6f452/mmseqs-linux-avx2.tar.gz
             tar xvfz mmseqs-linux-avx2.tar.gz
             echo $(pwd)/mmseqs/bin/ >> $GITHUB_PATH
 
@@ -48,7 +48,7 @@ jobs:
         run: |
             # install iAlign:
             # https://sites.gatech.edu/cssb/ialign/
-            wget http://cssb2.biology.gatech.edu/skolnick/files/iAlign/ialign_64_v1.1b2.tar.gz
+            curl -LO http://cssb2.biology.gatech.edu/skolnick/files/iAlign/ialign_64_v1.1b2.tar.gz
             tar xvzf ialign_64_v1.1b2.tar.gz
             # https://www.scivision.dev/github-actions-path-append/
             echo $(pwd)/ialign/bin/ >> $GITHUB_PATH

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,20 @@ data = [
     "colormath",
 ]
 
+# sklearn 1.2.2 doesn't ship wheels for py312. The old sklearn version is only required for PRODIGY-cryst.
+datapy312 = [
+    "fire",
+    "gemmi",
+    "networkx",
+    "scikit-learn",
+    "python-graphql-client",
+    "mpire",
+    "matplotlib",
+    "seaborn",
+    "colormath",
+]
+
+
 dev = [
     "pinder[lint,test,type,leaderboard,data]",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "pinder"
 dynamic = ["version"]
 dependencies = [
-    "biotite < 1.0.0",
+    "biotite >= 1.0",
     "fastpdb",
     "numpy<2",
     "pandas",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
 ]
 description = "PINDER: The Protein INteraction Dataset and Evaluation Resource"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: Apache Software License",

--- a/src/pinder-core/pinder/core/structure/atoms.py
+++ b/src/pinder-core/pinder/core/structure/atoms.py
@@ -25,9 +25,9 @@ _AtomArrayOrStack = Union[AtomArray, AtomArrayStack]
 
 
 def biotite_pdbxfile() -> TextFile:
-    from biotite.structure.io.pdbx import PDBxFile
+    from biotite.structure.io.pdbx import CIFFile
 
-    return PDBxFile
+    return CIFFile
 
 
 def biotite_pdbfile() -> TextFile:

--- a/tests/data/test_get_data.py
+++ b/tests/data/test_get_data.py
@@ -104,7 +104,7 @@ def test_get_interacting_chains(pdb_5cq2):
 def test_interacting_chains_method_regression(
     test_mmcif, radius, backbone_only, expect_equal, pinder_data_cp
 ):
-    from biotite.structure.io.pdbx import PDBxFile, get_structure
+    from biotite.structure.io.pdbx import CIFFile, get_structure
     import biotite.structure as struc
 
     next_gen = pinder_data_cp / "nextgen_rcsb"

--- a/tox.ini
+++ b/tox.ini
@@ -61,7 +61,7 @@ commands =
 
 
 [testenv:{py312}-test]
-tox_extras = test, data312
+tox_extras = test, datapy312
 allowlist_externals = pytest
 commands_pre =
     pip install 'torch==2.3.1'

--- a/tox.ini
+++ b/tox.ini
@@ -56,6 +56,6 @@ commands_pre =
     pip install git+https://github.com/yusuf1759/prodigy-cryst.git
     pip install -e .
 commands =
-  py39: pytest -vv {posargs: src tests README.md}
-  py310: pytest -vv {posargs: src tests README.md} --cov=pinder --cov-report=term-missing:skip-covered --cov-fail-under=80
-  py311: pytest -vv {posargs: src tests README.md}
+  py310: pytest -vv {posargs: src tests README.md}
+  py311: pytest -vv {posargs: src tests README.md} --cov=pinder --cov-report=term-missing:skip-covered --cov-fail-under=80
+  py312: pytest -vv {posargs: src tests README.md}

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py39,py310,py311}-lint,{py39,py310,py311}-type,{py39,py310,py311}-test
+envlist = {py310,py311,py312}-lint,{py310,py311,py312}-type,{py310,py311,py312}-test
 isolated_build = true
 requires =
     tox-extras==0.0.1
@@ -7,9 +7,9 @@ requires =
 
 [gh-actions]
 python =
-    3.9: py39
     3.10: py310
     3.11: py311
+    3.12: py312
 
 [testenv]
 passenv =
@@ -20,14 +20,14 @@ allowlist_externals =
     mmseq
     ialign.pl
 
-[testenv:{py39,py310,py311}-lint]
+[testenv:{py310,py311,py312}-lint]
 skip_sdist = true
 skip_install = true
 tox_extras = lint
 commands =
     pre-commit run --all-files --show-diff-on-failure
 
-[testenv:{py39,py310,py311}-type]
+[testenv:{py310,py311,py312}-type]
 skip_sdist = true
 skip_install = true
 tox_extras = type
@@ -47,7 +47,7 @@ precision = 2
 include_namespace_packages = true
 
 
-[testenv:{py39,py310,py311}-test]
+[testenv:{py310,py311,py312}-test]
 tox_extras = test, data
 allowlist_externals = pytest
 commands_pre =

--- a/tox.ini
+++ b/tox.ini
@@ -47,7 +47,7 @@ precision = 2
 include_namespace_packages = true
 
 
-[testenv:{py310,py311,py312}-test]
+[testenv:{py310,py311}-test]
 tox_extras = test, data
 allowlist_externals = pytest
 commands_pre =
@@ -58,4 +58,14 @@ commands_pre =
 commands =
   py310: pytest -vv {posargs: src tests README.md}
   py311: pytest -vv {posargs: src tests README.md} --cov=pinder --cov-report=term-missing:skip-covered --cov-fail-under=80
+
+
+[testenv:{py312}-test]
+tox_extras = test, data312
+allowlist_externals = pytest
+commands_pre =
+    pip install 'torch==2.3.1'
+    pip install torch-cluster -f https://data.pyg.org/whl/torch-2.3.1+cpu.html
+    pip install -e .
+commands =
   py312: pytest -vv {posargs: src tests README.md}


### PR DESCRIPTION
Closes #27 

* Breaking changes introduced in first major release of biotite which will subsequently be breaking changes to pinder for any with existing biotite installations with versions prior to major release 1.0.0. 
* Removes support for python <= 3.9
* Adds support for python 3.12
  * Note: it is not possible to use all of pinder-data package if using python 3.12 due to the sklearn version pin coming from PRODIGY-Cryst. If this functionality is not needed, the rest works as normal.

